### PR TITLE
Add optional sleep mode and a message ID filter for a link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ file(GLOB cmavnode_SRC
 add_executable(cmavnode ${cmavnode_SRC})
 set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG")
 set(CMAKE_CXX_FLAGS_DEBUG " -ggdb")
-set(CMAKE_CXX_FLAGS "-std=c++11")
+set(CMAKE_CXX_FLAGS "-std=c++11 -DMAVLINK_USE_MESSAGE_INFO")
 
 TARGET_LINK_LIBRARIES(cmavnode ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${READLINE_LIBRARY})
 

--- a/src/configfile.cpp
+++ b/src/configfile.cpp
@@ -1,6 +1,7 @@
 #include "configfile.h"
 
 #include <fstream>
+#include "../include/mavlink2/mavlink_get_info.h"
 
 int readConfigFile(std::string &filename, std::vector<std::shared_ptr<mlink> > &links)
 {
@@ -189,6 +190,72 @@ void readLinkInfo(ConfigFile* _configFile, std::string thisSection, link_info* _
 
     // Enable sleep mode for the link
     _configFile->boolValue(thisSection, "sleep", &_info->sleep_enabled);
+
+    std::string filter_string;
+    if (_configFile->strValue(thisSection, "filter", &filter_string))
+    {
+        // Find the filter type separator
+        size_t filter_type_separator = filter_string.find_first_of(':');
+
+        // Filter type seporator has been found
+        if (filter_type_separator != std::string::npos)
+        {
+            const std::unordered_map<std::string, link_filter_type> filter_type_map = 
+            {
+                { "DROP", link_filter_type::DROP },
+                { "ACCEPT", link_filter_type::ACCEPT },
+            };
+
+            // Extract the filter type string
+            std::string filter_type_str = filter_string.substr(0, filter_type_separator);
+
+            // Find the binding in the map
+            auto filter_type_iter = filter_type_map.find(filter_type_str);
+
+            // It's a valid filter type
+            if (filter_type_iter != filter_type_map.end())
+            {
+                // Extract the filter messages string
+                std::string filter_messages_str = filter_string.substr(filter_type_separator + 1);
+
+                std::vector<std::string> messages_strs;
+
+                boost::split(messages_strs, filter_messages_str, boost::is_any_of(","));
+
+                // Filter is not empty
+                if (messages_strs[0].length())
+                {
+                    _info->filter_type = filter_type_iter->second;
+
+                    const mavlink_message_info_t *message_info;
+
+                    // For every message name
+                    for (const std::string &filter_message_str : messages_strs) {
+                        // Find the MAVLink message information
+                        message_info = mavlink_get_message_info_by_name(filter_message_str.c_str());
+
+                        // Valid message name
+                        if (message_info)
+                            _info->filter_messages.insert(message_info->msgid);
+                        // Invalid message name
+                        else
+                        std::cout << "Failed to add message \"" << filter_message_str << "\" to the filter. Unknown message!"
+                            << std::endl; 
+                    } 
+                }
+                // Empty filter
+                else
+                    std::cout << "Failed to load filter for \"" << _info->link_name << "\". No messages!" << std::endl;
+            }
+            // Unknown filter type
+            else 
+                std::cout << "Failed to load filter for \"" << _info->link_name << "\". Uknown filter type \"" <<
+                    filter_type_str << "\"!" << std::endl;
+        }
+        // No filter message type
+        else
+            std::cout << "Failed to load filter for \"" << _info->link_name << "\". No filter type found!" << std::endl;
+    }
 }
 
 std::string trim(std::string const& source, char const* delims = " \t\r\n")

--- a/src/configfile.cpp
+++ b/src/configfile.cpp
@@ -186,6 +186,9 @@ void readLinkInfo(ConfigFile* _configFile, std::string thisSection, link_info* _
 
     // Identify SiK radio links
     _configFile->boolValue(thisSection, "sik_radio", &_info->SiK_radio);
+
+    // Enable sleep mode for the link
+    _configFile->boolValue(thisSection, "sleep", &_info->sleep_enabled);
 }
 
 std::string trim(std::string const& source, char const* delims = " \t\r\n")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -160,6 +160,17 @@ bool should_forward_message(mavlink_message_t &msg, std::shared_ptr<mlink> *inco
     if (((*outgoing_link)->info.sleep_enabled) && ((*outgoing_link)->sleep))
         return false;
 
+    // Filter is presented
+    if ((*outgoing_link)->info.filter_type != link_filter_type::NONE)
+    {
+        // The current message type is in the filter messages set
+        bool message_found = (*outgoing_link)->info.filter_messages.find(msg.msgid) != (*outgoing_link)->info.filter_messages.end();
+
+        if (message_found && ((*outgoing_link)->info.filter_type == link_filter_type::DROP) ||
+                (!message_found && ((*outgoing_link)->info.filter_type == link_filter_type::ACCEPT)))
+            return false;
+    }
+
     // Don't forward SiK radio info
     if ((*incoming_link)->info.SiK_radio && msg.sysid == 51)
     {

--- a/src/mlink.cpp
+++ b/src/mlink.cpp
@@ -17,6 +17,8 @@ std::set<uint8_t> mlink::sysIDs_all_links;
 mlink::mlink(link_info info_)
 {
     info = info_;
+    // No clients at this moment
+    sleep = true;
     static_link_delay.push_back(boost::posix_time::time_duration(0,0,0,0));
 
     //if we are simulating init the random generator

--- a/src/mlink.h
+++ b/src/mlink.h
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <tuple>
 #include <unordered_map>
+#include <unordered_set>
 #include <map>
 #include <vector>
 #include <utility>
@@ -55,6 +56,13 @@ struct queue_counter
     }
 };
 
+enum class link_filter_type
+{
+    NONE,
+    DROP, // Drop only messages listed in a filter
+    ACCEPT  // Accept only messages listed in a filter
+};
+
 struct link_info
 {
     std::string link_name;
@@ -65,6 +73,8 @@ struct link_info
     bool reject_repeat_packets = false;
     bool SiK_radio = false;
     bool sleep_enabled = false;
+    link_filter_type filter_type = link_filter_type::NONE;
+    std::unordered_set<uint8_t> filter_messages;
 };
 
 class mlink

--- a/src/mlink.h
+++ b/src/mlink.h
@@ -64,6 +64,7 @@ struct link_info
     int sim_packet_loss = 0; //0-100, amount of packets that should be dropped
     bool reject_repeat_packets = false;
     bool SiK_radio = false;
+    bool sleep_enabled = false;
 };
 
 class mlink
@@ -107,6 +108,9 @@ public:
     bool is_kill = false;
     long totalPacketCount = 0;
     long totalPacketSent = 0;
+
+    // No activity on the endpoint
+    bool sleep;
 
     // Track link quality for the link
     struct link_quality_stats


### PR DESCRIPTION
Sometimes we use LTE connection with a limited traffic volume to control our vehicles from Internet. It's very useful in this case to drop all outcoming MAVLink messages to some links while there are no clients on the other side.

This commit will add an additional option "sleep" for every link.