### PR TITLE
Add optional sleep mode

### DIFF
--- a/src/configfile.cpp
+++ b/src/configfile.cpp
@@ -186,6 +186,9 @@ void readLinkInfo(ConfigFile* _configFile, std::string thisSection, link_info* _
 
     // Identify SiK radio links
     _configFile->boolValue(thisSection, "sik_radio", &_info->SiK_radio);
+
+    // Enable sleep mode for the link
+    _configFile->boolValue(thisSection, "sleep", &_info->sleep_enabled);
 }
 
 std::string trim(std::string const& source, char const* delims = " \t\r\n")

--- a/src/mlink.cpp
+++ b/src/mlink.cpp
@@ -17,6 +17,8 @@ std::set<uint8_t> mlink::sysIDs_all_links;
 mlink::mlink(link_info info_)
 {
     info = info_;
+    // No clients at this moment
+    sleep = true;
     static_link_delay.push_back(boost::posix_time::time_duration(0,0,0,0));
 
     //if we are simulating init the random generator

--- a/src/mlink.h
+++ b/src/mlink.h
@@ -64,6 +64,7 @@ struct link_info
     int sim_packet_loss = 0; //0-100, amount of packets that should be dropped
     bool reject_repeat_packets = false;
     bool SiK_radio = false;
+    bool sleep_enabled = false;
 };
 
 class mlink
@@ -107,6 +108,9 @@ public:
     bool is_kill = false;
     long totalPacketCount = 0;
     long totalPacketSent = 0;
+
+    // No activity on the endpoint
+    bool sleep;
 
     // Track link quality for the link
     struct link_quality_stats


### PR DESCRIPTION
Sometimes we use LTE connection with a limited traffic volume to control our vehicles from Internet. It's very useful in this case to drop all outcoming MAVLink messages to some links while there are no clients on the other side.

This commit will add an additional option "sleep" for every link.