### PR TITLE
Add a message ID filter for a link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ file(GLOB cmavnode_SRC
 add_executable(cmavnode ${cmavnode_SRC})
 set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG")
 set(CMAKE_CXX_FLAGS_DEBUG " -ggdb")
-set(CMAKE_CXX_FLAGS "-std=c++11")
+set(CMAKE_CXX_FLAGS "-std=c++11 -DMAVLINK_USE_MESSAGE_INFO")
 
 TARGET_LINK_LIBRARIES(cmavnode ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${READLINE_LIBRARY})
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -156,6 +156,17 @@ bool should_forward_message(mavlink_message_t &msg, std::shared_ptr<mlink> *inco
         return false;
     }
 
+    // Filter is presented
+    if ((*outgoing_link)->info.filter_type != link_filter_type::NONE)
+    {
+        // The current message type is in the filter messages set
+        bool message_found = (*outgoing_link)->info.filter_messages.find(msg.msgid) != (*outgoing_link)->info.filter_messages.end();
+
+        if (message_found && ((*outgoing_link)->info.filter_type == link_filter_type::DROP) ||
+                (!message_found && ((*outgoing_link)->info.filter_type == link_filter_type::ACCEPT)))
+            return false;
+    }
+
     // Don't forward SiK radio info
     if ((*incoming_link)->info.SiK_radio && msg.sysid == 51)
     {

--- a/src/mlink.h
+++ b/src/mlink.h
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <tuple>
 #include <unordered_map>
+#include <unordered_set>
 #include <map>
 #include <vector>
 #include <utility>
@@ -55,6 +56,13 @@ struct queue_counter
     }
 };
 
+enum class link_filter_type
+{
+    NONE,
+    DROP, // Drop only messages listed in a filter
+    ACCEPT  // Accept only messages listed in a filter
+};
+
 struct link_info
 {
     std::string link_name;
@@ -64,6 +72,8 @@ struct link_info
     int sim_packet_loss = 0; //0-100, amount of packets that should be dropped
     bool reject_repeat_packets = false;
     bool SiK_radio = false;
+    link_filter_type filter_type = link_filter_type::NONE;
+    std::unordered_set<uint8_t> filter_messages;
 };
 
 class mlink


### PR DESCRIPTION
This commit will add an optional MAVLink message filter by a message ID for a link.

Option format:
filter = <DROP|ACCEPT>:<Message ID 1>,...,

DROP - drop only messages from a message list,
ACCEPT - accept only messages from a message list.

- string message ID representation (SYS_STATUS, GPS_RTCM_DATA, etc.).